### PR TITLE
Simplify materializations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ objects in another schema. You'll get this error from SQLite: "view [someview]
 cannot reference objects in database [somedatabase]". You must set
 `materialized='table'` in models that reference other schemas.
 
+- Materializations are simplified: they drop and re-create the model, instead of
+doing the backup-and-swap-in new mode that the other dbt database adapters
+support. This choice was made because SQLite doesn't support `DROP ... CASCADE`
+or `ALTER VIEW` or provide information about relation dependencies in a
+information_schema-like relation. Taken together, these limitations make it really
+difficult to make the backup-and-swap-in functionality work properly.
+
 - Columns with numeric data in seed files won't load correctly unless you
 explicitly specify 'int' datatype in the seeds configuration. You'll get an error
 like "Error binding parameter N - probably unsupported type." (This doesn't

--- a/dbt/include/sqlite/macros/materializations/table/table.sql
+++ b/dbt/include/sqlite/macros/materializations/table/table.sql
@@ -1,0 +1,34 @@
+{% materialization table, adapter='sqlite' %}
+  {%- set identifier = model['alias'] -%}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier,
+                                                schema=schema,
+                                                database=database,
+                                                type='table') -%}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% if old_relation is not none %}
+    {{ adapter.drop_relation(old_relation) }}
+  {% endif %}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ create_table_as(False, target_relation, sql) }}
+  {%- endcall %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {% do persist_docs(target_relation, model) %}
+
+  -- `COMMIT` happens here
+  {{ adapter.commit() }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/dbt/include/sqlite/macros/materializations/view/view.sql
+++ b/dbt/include/sqlite/macros/materializations/view/view.sql
@@ -1,0 +1,33 @@
+{%- materialization view, adapter='sqlite' -%}
+
+  {%- set identifier = model['alias'] -%}
+
+  {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database,
+                                                type='view') -%}
+
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
+
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% if old_relation is not none %}
+    {{ adapter.drop_relation(old_relation) }}
+  {% endif %}
+
+  -- build model
+  {% call statement('main') -%}
+    {{ create_view_as(target_relation, sql) }}
+  {%- endcall %}
+
+  {% do persist_docs(target_relation, model) %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  {{ adapter.commit() }}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+  {{ return({'relations': [target_relation]}) }}
+
+{%- endmaterialization -%}


### PR DESCRIPTION
This PR overrides the default materializations to skip creating backup/tmp relations. Limitations in SQLite make this really difficult to support. Details have been added to the README