### PR TITLE
Adapter-specific profile template

### DIFF
--- a/dbt/include/sqlite/sample_profiles.yml
+++ b/dbt/include/sqlite/sample_profiles.yml
@@ -3,54 +3,20 @@ default:
 
     dev:
       type: sqlite
-
-      # sqlite locks the whole db on writes so anything > 1 won't help
       threads: 1
-
-      database: [database name]
-
-      # value of 'schema' must be defined in `schemas_and_paths` below. in most cases,
-      # this should be 'main'
+      database: <database name>
       schema: 'main'
-
-      # connect schemas to paths: at least one of these must be 'main'
-      # semi-colon separated list of file paths
-      # format: 'schema_1=/my_project/data/file_1.db;schema_2=/my_project/data/file_2.db'
       schemas_and_paths: 'main=/my_project/data/etl.db'
-
-      # directory where all *.db files are attached as schemata, using base filename
-      # as schema name, and where new schemata are created. this can overlap with the dirs of
-      # files in `schemas_and_paths` as long as there's no conflicts.
       schema_directory: '/my_project/data'
-
-      # optional: semi-colon separated list of file paths for SQLite extensions to load.
-      # digest.so is needed to provide for snapshots to work; see README
       extensions: '/path/to/sqlite-digest/digest.so'
 
     prod:
       type: sqlite
-
-      # sqlite locks the whole db on writes so anything > 1 won't help
       threads: 1
-
-      database: [database name]
-
-      # value of 'schema' must be defined in `schemas_and_paths` below. in most cases,
-      # this should be 'main'
+      database: <database name>
       schema: 'main'
-
-      # connect schemas to paths: at least one of these must be 'main'
-      # semi-colon separated list of file paths
-      # format: 'schema_1=/my_project/data/file_1.db;schema_2=/my_project/data/file_2.db'
       schemas_and_paths: 'main=/my_project/data/etl.db'
-
-      # directory where all *.db files are attached as schemata, using base filename
-      # as schema name, and where new schemata are created. this can overlap with the dirs of
-      # files in `schemas_and_paths` as long as there's no conflicts.
       schema_directory: '/my_project/data'
-
-      # optional: semi-colon separated list of file paths for SQLite extensions to load.
-      # digest.so is needed to provide for snapshots to work; see README
       extensions: '/path/to/sqlite-digest/digest.so'
 
   target: dev

--- a/dbt/include/sqlite/sample_profiles.yml
+++ b/dbt/include/sqlite/sample_profiles.yml
@@ -1,0 +1,56 @@
+default:
+  outputs:
+
+    dev:
+      type: sqlite
+
+      # sqlite locks the whole db on writes so anything > 1 won't help
+      threads: 1
+
+      database: [database name]
+
+      # value of 'schema' must be defined in `schemas_and_paths` below. in most cases,
+      # this should be 'main'
+      schema: 'main'
+
+      # connect schemas to paths: at least one of these must be 'main'
+      # semi-colon separated list of file paths
+      # format: 'schema_1=/my_project/data/file_1.db;schema_2=/my_project/data/file_2.db'
+      schemas_and_paths: 'main=/my_project/data/etl.db'
+
+      # directory where all *.db files are attached as schemata, using base filename
+      # as schema name, and where new schemata are created. this can overlap with the dirs of
+      # files in `schemas_and_paths` as long as there's no conflicts.
+      schema_directory: '/my_project/data'
+
+      # optional: semi-colon separated list of file paths for SQLite extensions to load.
+      # digest.so is needed to provide for snapshots to work; see README
+      extensions: '/path/to/sqlite-digest/digest.so'
+
+    prod:
+      type: sqlite
+
+      # sqlite locks the whole db on writes so anything > 1 won't help
+      threads: 1
+
+      database: [database name]
+
+      # value of 'schema' must be defined in `schemas_and_paths` below. in most cases,
+      # this should be 'main'
+      schema: 'main'
+
+      # connect schemas to paths: at least one of these must be 'main'
+      # semi-colon separated list of file paths
+      # format: 'schema_1=/my_project/data/file_1.db;schema_2=/my_project/data/file_2.db'
+      schemas_and_paths: 'main=/my_project/data/etl.db'
+
+      # directory where all *.db files are attached as schemata, using base filename
+      # as schema name, and where new schemata are created. this can overlap with the dirs of
+      # files in `schemas_and_paths` as long as there's no conflicts.
+      schema_directory: '/my_project/data'
+
+      # optional: semi-colon separated list of file paths for SQLite extensions to load.
+      # digest.so is needed to provide for snapshots to work; see README
+      extensions: '/path/to/sqlite-digest/digest.so'
+
+  target: dev

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
             'macros/**/*.sql',
             'macros/**/**/*.sql',
             'dbt_project.yml',
+            'sample_profiles.yml',
         ]
     },
     install_requires=[


### PR DESCRIPTION
## Overview
Starting in dbt v0.18.0, the `dbt init` allows an optional `--adapter`. If you do, dbt will create `~/.dbt/profiles.yml` (if one does not already exist) in accordance with the intended adapter type.

The dbt documentation includes a [note for plugin authors](https://docs.getdbt.com/reference/commands/init/#adapter-specific-profile:~:text=Note%20for%20plugin%20authors) that the `--adapter` flag looks for a file named `dbt/include/[adapter_name]/sample_profiles.yml`. The provided examples are [dbt-spark](https://github.com/fishtown-analytics/dbt-spark/tree/master/dbt/include/spark/sample_profiles.yml) and [dbt-presto](https://github.com/fishtown-analytics/dbt-presto/blob/master/dbt/include/presto/sample_profiles.yml).

This pull request adds that file.

## Testing
2 cases were tested:
1. `~/.dbt/profiles.yml` does not already exist
1. `~/.dbt/profiles.yml` already exists

In the former case, a new `~/.dbt/profiles.yml` file is created, and it contains the template from `dbt/include/sqlite/sample_profiles.yml`.

In the latter case, the `sample_profiles.yml` file is ignored and it is completely up to the user to add the relevant configuration ([as directed in the `README`](https://github.com/codeforkjeff/dbt-sqlite#how-to-use-this)).