### PR TITLE
Use YAML objects instead of colon-separated strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ dbt_sqlite:
 
       # optional: semi-colon separated list of file paths for SQLite extensions to load.
       # crypto.so is needed to provide for snapshots to work; see README
-      extensions: "/path/to/sqlean/crypto.so"
+      extensions:
+        - "/path/to/sqlean/crypto.so"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ dbt_sqlite:
       schema: 'main'
 
       # connect schemas to paths: at least one of these must be 'main'
-      schemas_and_paths: 'main=/my_project/data/etl.db;dataset=/my_project/data/dataset_v1.db'
+      schemas_and_paths:
+        main: '/my_project/data/etl.db'
+        dataset: '/my_project/data/dataset_v1.db'
 
       # directory where all *.db files are attached as schema, using base filename
       # as schema name, and where new schema are created. this can overlap with the dirs of

--- a/dbt/adapters/sqlite/connections.py
+++ b/dbt/adapters/sqlite/connections.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import glob
 import os.path
 import sqlite3
-from typing import Optional, Tuple, Any
+from typing import Optional, Tuple, Any, Dict
 
 
 from dbt.adapters.base import Credentials
@@ -23,7 +23,7 @@ from dbt.logger import GLOBAL_LOGGER as logger
 class SQLiteCredentials(Credentials):
     """ Required connections for a SQLite connection"""
 
-    schemas_and_paths: str
+    schemas_and_paths: Dict[str, str]
     schema_directory: str
     extensions: Optional[str] = None
 
@@ -48,8 +48,7 @@ class SQLiteConnectionManager(SQLConnectionManager):
         credentials = connection.credentials
 
         schemas_and_paths = {}
-        for path_entry in credentials.schemas_and_paths.split(";"):
-            schema, path = path_entry.split("=", 1)
+        for schema, path in credentials.schemas_and_paths.items():
             # store abs path so we can tell if we've attached the file already
             schemas_and_paths[schema] = os.path.abspath(path)
 

--- a/dbt/include/sqlite/sample_profiles.yml
+++ b/dbt/include/sqlite/sample_profiles.yml
@@ -6,17 +6,21 @@ default:
       threads: 1
       database: <database name>
       schema: 'main'
-      schemas_and_paths: 'main=/my_project/data/etl.db'
+      schemas_and_paths:
+        main: '/my_project/data/etl.db'
       schema_directory: '/my_project/data'
-      extensions: '/path/to/sqlite-digest/digest.so'
+      extensions:
+        - '/path/to/sqlite-digest/digest.so'
 
     prod:
       type: sqlite
       threads: 1
       database: <database name>
       schema: 'main'
-      schemas_and_paths: 'main=/my_project/data/etl.db'
+      schemas_and_paths:
+        main: '/my_project/data/etl.db'
       schema_directory: '/my_project/data'
-      extensions: '/path/to/sqlite-digest/digest.so'
+      extensions:
+        - '/path/to/sqlite-digest/digest.so'
 
   target: dev

--- a/test/sqlite.dbtspec
+++ b/test/sqlite.dbtspec
@@ -3,7 +3,8 @@ target:
   type: sqlite
   database: adapter_test
   schema: 'main'
-  schemas_and_paths: "main=/tmp/dbt-sqlite-tests/adapter_test.db"
+  schemas_and_paths:
+    main: '/tmp/dbt-sqlite-tests/adapter_test.db'
   schema_directory: '/tmp/dbt-sqlite-tests'
   extensions: "/home/jeff/git/sqlite-digest/digest.so"
   threads: 1

--- a/test/sqlite.dbtspec
+++ b/test/sqlite.dbtspec
@@ -6,7 +6,8 @@ target:
   schemas_and_paths:
     main: '/tmp/dbt-sqlite-tests/adapter_test.db'
   schema_directory: '/tmp/dbt-sqlite-tests'
-  extensions: "/home/jeff/git/sqlite-digest/digest.so"
+  extensions:
+    - "/home/spoton/edgar/sqlite-digest/digest.so"
   threads: 1
 sequences:
   test_dbt_empty: empty


### PR DESCRIPTION
The use of a colon-separated string can be hard to read when there are more than a few datafiles:

```yaml
schemas_and_paths: 'main=/my_project/data/main.db;source1=/my_project/data/source1.db;source2=/my_project/data/source2.db'
```

Using a YAML object should allow users to define the file-schema mapping in a friendlier way:

```yaml
schemas_and_paths:
  main: /my_project/data/main.db
  source1: /my_project/data/source1.db
  source2: /my_project/data/source2.db
```

A similar thing happens with SQLite extensions:

```yaml
extensions:
  - /path/to/sqlite-digest/digest.so
```

I've tested this locally with `pytest test/sqlite.dbtspec` and the 9 tests pass.

btw @codeforkjeff, thanks for creating this project!