### PR TITLE
check if schema exists before calling DETACH DATABASE

### DIFF
--- a/dbt/adapters/sqlite/impl.py
+++ b/dbt/adapters/sqlite/impl.py
@@ -244,6 +244,11 @@ class SQLiteAdapter(SQLAdapter):
     def drop_schema(self, relation: BaseRelation) -> None:
         super().drop_schema(relation)
 
+        # can't detach a databse in the middle of a transaction, so commit first.
+        # I wonder if drop_schema() in SQLAdapter should do this, since create_schema() does.
+        self.commit_if_has_connection()
+
         # never detach main
         if relation.schema != 'main':
-            self.connections.execute(f"DETACH DATABASE {relation.schema}")
+            if self.check_schema_exists(relation.database, relation.schema):
+                self.connections.execute(f"DETACH DATABASE {relation.schema}")


### PR DESCRIPTION
sqlite doesn't support IF EXISTS for DETACH ATTACHMENT so we check manually. Note that we have to commit before detaching, otherwise sqlite will raise a 'database is locked' error.

This issue was exposed when changing the test suite to use the new framework for dbt-core 1.1.0. It's not clear to me that this ever comes up in real world use cases, but fixing it anyway just in case.