### PR TITLE
Use new test framework for dbt-core 1.1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,9 @@ RUN mkdir -p /tmp/dbt-sqlite-tests
 
 RUN cd /tmp/dbt-sqlite-tests && wget https://github.com/nalgeon/sqlean/releases/download/0.12.2/crypto.so
 
-RUN pip install dbt-core~=1.0.0
+RUN pip install dbt-core~=1.1.0
 
-# NOTE: dbt 0.19.x doesn't work with pytest-dbt-adapter >= 0.5.0; use 0.4.0
-# see https://github.com/dbt-labs/dbt-adapter-tests/issues/20
-#
-# pytest-dbt-adapter 0.6.0 doesn't seem to work with dbt 0.21.1,
-# I think it's intended for the forthcoming 1.0.0 dbt release?
-RUN pip install pytest-dbt-adapter==0.6.0
+RUN pip install pytest pytest-dotenv dbt-tests-adapter==1.1.0
 
 # dbt-sqlite overrides some stuff pertaining to 'docs generate'
 # so exercise it using jaffle_shop repo

--- a/dbt/adapters/sqlite/__version__.py
+++ b/dbt/adapters/sqlite/__version__.py
@@ -1,1 +1,1 @@
-version = '1.0.1'
+version = '1.1.0'

--- a/dbt/adapters/sqlite/impl.py
+++ b/dbt/adapters/sqlite/impl.py
@@ -244,7 +244,7 @@ class SQLiteAdapter(SQLAdapter):
     def drop_schema(self, relation: BaseRelation) -> None:
         super().drop_schema(relation)
 
-        # can't detach a databse in the middle of a transaction, so commit first.
+        # can't detach a database in the middle of a transaction, so commit first.
         # I wonder if drop_schema() in SQLAdapter should do this, since create_schema() does.
         self.commit_if_has_connection()
 

--- a/dbt/adapters/sqlite/impl.py
+++ b/dbt/adapters/sqlite/impl.py
@@ -246,4 +246,6 @@ class SQLiteAdapter(SQLAdapter):
 
         # never detach main
         if relation.schema != 'main':
+            # FIXME: this breaks: causes "database is locked" error.
+            #if self.check_schema_exists(relation.database, relation.schema):
             self.connections.execute(f"DETACH DATABASE {relation.schema}")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+filterwarnings =
+    ignore:.*'soft_unicode' has been renamed to 'soft_str'*:DeprecationWarning
+    ignore:unclosed file .*:ResourceWarning
+env_files =
+    test.env  # uses pytest-dotenv plugin
+              # this allows you to store env vars for database connection in a file named test.env
+              # rather than passing them in every CLI command, or setting in `PYTEST_ADDOPTS`
+              # be sure to add "test.env" to .gitignore as well!
+testpaths =
+    tests/functional  # name per convention

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ pip install -e .
 # Leaving the database file between runs of pytest can mess up subsequent test runs.
 # Since this runs in a fresh container each time, it's not an issue.
 
-pytest test/sqlite.dbtspec
+python3 -m pytest tests/functional
 
 ####
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+import os
+
+# Import the standard functional fixtures as a plugin
+# Note: fixtures with session scope need to be local
+pytest_plugins = ["dbt.tests.fixtures.project"]
+
+# The profile dictionary, used to write out profiles.yml
+# dbt will supply a unique schema per test, so we do not specify 'schema' here
+@pytest.fixture(scope="class")
+def dbt_profile_target():
+    return {
+        'type': 'sqlite',
+        'threads': 1,
+        'database': 'adapter_test',
+        'schema': 'main',
+        'schemas_and_paths': {
+            'main': '/tmp/dbt-sqlite-tests/adapter_test.db'
+        },
+        'schema_directory': '/tmp/dbt-sqlite-tests',
+        'extensions' : [
+            "/tmp/dbt-sqlite-tests/crypto.so"
+        ]
+    }

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -1,0 +1,51 @@
+import pytest
+
+from dbt.tests.adapter.basic.test_base import BaseSimpleMaterializations
+from dbt.tests.adapter.basic.test_singular_tests import BaseSingularTests
+from dbt.tests.adapter.basic.test_singular_tests_ephemeral import BaseSingularTestsEphemeral
+from dbt.tests.adapter.basic.test_empty import BaseEmpty
+from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
+from dbt.tests.adapter.basic.test_incremental import BaseIncremental
+from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
+from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
+from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
+from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
+
+class TestSimpleMaterializationsSqlite(BaseSimpleMaterializations):
+    pass
+
+
+class TestSingularTestsSqlite(BaseSingularTests):
+    pass
+
+
+class TestSingularTestsEphemeralSqlite(BaseSingularTestsEphemeral):
+    pass
+
+
+class TestEmptySqlite(BaseEmpty):
+    pass
+
+
+class TestEphemeralSqlite(BaseEphemeral):
+    pass
+
+
+class TestIncrementalSqlite(BaseIncremental):
+    pass
+
+
+class TestGenericTestsSqlite(BaseGenericTests):
+    pass
+
+
+class TestSnapshotCheckColsSqlite(BaseSnapshotCheckCols):
+    pass
+
+
+class TestSnapshotTimestampSqlite(BaseSnapshotTimestamp):
+    pass
+
+
+class TestBaseAdapterMethod(BaseAdapterMethod):
+    pass


### PR DESCRIPTION
dbt-core 1.1.0 provides a new test framework, so use it.

See https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-v1.1
