### PR TITLE
Issue #30: Improve type handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,14 @@ RUN wget -q https://github.com/nalgeon/sqlean/releases/download/0.15.2/text.so
 
 WORKDIR /opt/dbt-sqlite/src 
 
-COPY . .
+COPY setup.py .
+COPY dbt ./dbt
 
 RUN pip install .
+
+COPY run_tests.sh .
+COPY pytest.ini .
+COPY tests ./tests
 
 ENV TESTDATA=/opt/dbt-sqlite/testdata
 

--- a/dbt/adapters/sqlite/impl.py
+++ b/dbt/adapters/sqlite/impl.py
@@ -24,7 +24,9 @@ class SQLiteAdapter(SQLAdapter):
     def date_function(cls):
         return 'date()'
 
-    # sqlite reports the exact string (including case) used when declaring a column of a certain type
+    # sqlite reports the exact string (including case) used when declaring a column of a certain type.
+    # the types here should correspond to affinities recognized by SQLite.
+    # see https://www.sqlite.org/datatype3.html
 
     @classmethod
     def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:
@@ -33,23 +35,23 @@ class SQLiteAdapter(SQLAdapter):
     @classmethod
     def convert_number_type(cls, agate_table: agate.Table, col_idx: int) -> str:
         decimals = agate_table.aggregate(agate.MaxPrecision(col_idx))  # type: ignore[attr-defined]
-        return "NUMERIC" if decimals else "INT"
+        return "REAL" if decimals else "INT"
 
     @classmethod
     def convert_boolean_type(cls, agate_table: agate.Table, col_idx: int) -> str:
-        return "BOOLEAN"
+        return "INT"
 
     @classmethod
     def convert_datetime_type(cls, agate_table: agate.Table, col_idx: int) -> str:
-        return "TIMESTAMP WITHOUT TIMEZONE"
+        return "TEXT"
 
     @classmethod
     def convert_date_type(cls, agate_table: agate.Table, col_idx: int) -> str:
-        return "DATE"
+        return "TEXT"
 
     @classmethod
     def convert_time_type(cls, agate_table: agate.Table, col_idx: int) -> str:
-        return "TIME"
+        return "TEXT"
 
     def get_live_relation_type(self, relation):
         """

--- a/dbt/adapters/sqlite/impl.py
+++ b/dbt/adapters/sqlite/impl.py
@@ -102,7 +102,7 @@ class SQLiteAdapter(SQLAdapter):
         for row in results:
             new_row = [
                 row[1],
-                row[2] or 'TEXT',
+                row[2] or 'UNKNOWN',
                 None,
                 None,
                 None

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -24,8 +24,6 @@ git clone --depth 1 https://github.com/dbt-labs/jaffle_shop.git
 
 cd jaffle_shop
 
-git pull
-
 mkdir -p /tmp/jaffle_shop
 
 mkdir -p $HOME/.dbt
@@ -57,4 +55,6 @@ jaffle_shop:
 
 EOF
 
+dbt seed
+dbt run
 dbt docs generate

--- a/run_tests_docker.sh
+++ b/run_tests_docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 docker build . -t dbt-sqlite
 
 docker run \

--- a/tests/functional/adapter/utils/test_data_types.py
+++ b/tests/functional/adapter/utils/test_data_types.py
@@ -6,14 +6,24 @@ from dbt.tests.adapter.utils.data_types.test_type_numeric import BaseTypeNumeric
 from dbt.tests.adapter.utils.data_types.test_type_string import BaseTypeString
 from dbt.tests.adapter.utils.data_types.test_type_timestamp import BaseTypeTimestamp
 
-# sqlite's table_info() pragma returns an empty type for columns in views
-# so we tweak the models in these tests to materialize as tables
+# These tests compare the resulting column types of CASTs against the types
+# inferred by agate when loading seeds.
+#
+# There's a Column class in dbt-core that's used by the default adapter implementation
+# of methods like [adapter].type_timestamp() to get a type for CASTs.
+#
+# Some quirks of SQLite that make these tests challenging:
+#
+# - a CAST seems to always result in an empty type (i.e. no type affinity) in views,
+#   but not in a CREATE TABLE AS. So we tweak the tests to materialize models as tables.
+#
+# - CASTs to an unrecognized type will result in the type being 'NUM' which is a bit
+#   mysterious.
 
 class TestTypeBigInt(BaseTypeBigInt):
     pass
 
     
-@pytest.mark.skip("TODO: fix this")
 class TestTypeFloat(BaseTypeFloat):
 
     models__actual_sql = """
@@ -40,29 +50,39 @@ select cast('12345678' as {{ type_int() }}) as int_col
         return {"actual.sql": self.interpolate_macro_namespace(self.models__actual_sql, "type_int")}
 
     
-@pytest.mark.skip("TODO: fix this")
 class TestTypeNumeric(BaseTypeNumeric):
-    def numeric_fixture_type(self):
-        return "numeric"
-
-    
-class TestTypeString(BaseTypeString):
-    pass
-
-    
-@pytest.mark.skip("TODO: fix this")
-class TestTypeTimestamp(BaseTypeTimestamp):
 
     models__actual_sql = """
 {{ config(materialized='table') }}
 
-select cast('2021-01-01 01:01:01' as {{ type_timestamp() }}) as timestamp_col
+select cast('1.2345' as {{ type_numeric() }}) as numeric_col
 """
 
     @pytest.fixture(scope="class")
     def models(self):
-        return {
-            "actual.sql": self.interpolate_macro_namespace(self.models__actual_sql, "type_timestamp")
-        }
+        return {"actual.sql": self.interpolate_macro_namespace(self.models__actual_sql, "type_numeric")}
+
+    def numeric_fixture_type(self):
+        return "NUM"
 
     
+class TestTypeString(BaseTypeString):
+
+    models__actual_sql = """
+{{ config(materialized='table') }}
+
+select cast('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+as {{ type_string() }}) as string_col
+"""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"actual.sql": self.interpolate_macro_namespace(self.models__actual_sql, "type_string")}
+
+
+# casting to TIMESTAMP results in an 'NUM' type which truncates the original value
+# to only the year portion. It's up to the user to properly deal with timestamps
+# values from source tables.
+@pytest.mark.skip("timestamp not supported in SQLite")
+class TestTypeTimestamp(BaseTypeTimestamp):
+    pass


### PR DESCRIPTION
Resolves issue #30 

- The convert functions in SQLiteAdapter now all return recognized affinities in SQLite.
- get_columns_in_relation() used to report a column's type as TEXT if SQLite didn't report any type affinity for the column. I think this was in place to make incremental models work. I changed this to UNKNOWN because that's less misleading. This is what will show up for column types in dbt-generated docs.
- Add notes to test_data_types about how types work in SQLite and do the best we can in those tests.