### PR TITLE
Update setup.py to avoid dependency conflicts between dbt-core and dbt-sqlite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         ]
     },
     install_requires=[
-        "dbt-core>=1.4.0"
+        "dbt-core~=1.4.0"
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
As mentioned in this [comment](https://github.com/codeforkjeff/dbt-sqlite/issues/43#issuecomment-1593119063) on #43, I have fixed the `setup.py` to use `dbt-core~=1.4`.