### PR TITLE
compatiblity for 1.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10"]
+        python_version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ubuntu-latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get -y install git python3 python3-pip python3-venv sq
 WORKDIR /opt/dbt-sqlite
 
 RUN python3 -m pip install --upgrade pip \
-    && python3 -m pip install pytest pytest-dotenv dbt-core~=1.4.0 dbt-tests-adapter~=1.4.0
+    && python3 -m pip install pytest pytest-dotenv dbt-core~=1.5.0 dbt-tests-adapter~=1.5.0
 
 RUN wget -q https://github.com/nalgeon/sqlean/releases/download/0.15.2/crypto.so
 RUN wget -q https://github.com/nalgeon/sqlean/releases/download/0.15.2/math.so

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Use the right version. Starting with the release of dbt-core 1.0.0,
 versions of dbt-sqlite are aligned to the same major+minor
 [version](https://semver.org/) of dbt-core.
 
+- versions 1.5.x of this adapter work with dbt-core 1.5.x
 - versions 1.4.x of this adapter work with dbt-core 1.4.x
 - versions 1.3.x of this adapter work with dbt-core 1.3.x
 - versions 1.2.x of this adapter work with dbt-core 1.2.x

--- a/dbt/adapters/sqlite/__version__.py
+++ b/dbt/adapters/sqlite/__version__.py
@@ -1,1 +1,1 @@
-version = '1.4.0'
+version = '1.5.0'

--- a/dbt/adapters/sqlite/connections.py
+++ b/dbt/adapters/sqlite/connections.py
@@ -2,6 +2,7 @@
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 import glob
+import json
 import os.path
 import sqlite3
 from typing import Optional, Tuple, Any, Dict, List
@@ -37,7 +38,7 @@ class SQLiteCredentials(Credentials):
         Hashed and included in anonymous telemetry to track adapter adoption.
         Pick a field that can uniquely identify one team/organization building with this adapter
         """
-        return self.host
+        return json.dumps(self.schemas_and_paths, sort_keys=True)
 
     def _connection_keys(self):
         """ Keys to show when debugging """
@@ -73,7 +74,7 @@ class SQLiteConnectionManager(SQLConnectionManager):
 
             for ext_path in credentials.extensions:
                 handle.load_extension(ext_path)
-            
+
             cursor = handle.cursor()
 
             for schema in set(schemas_and_paths.keys()) - set(['main']):

--- a/dbt/adapters/sqlite/connections.py
+++ b/dbt/adapters/sqlite/connections.py
@@ -2,9 +2,9 @@
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 import glob
-import json
 import os.path
 import sqlite3
+from socket import gethostname
 from typing import Optional, Tuple, Any, Dict, List
 
 
@@ -38,7 +38,7 @@ class SQLiteCredentials(Credentials):
         Hashed and included in anonymous telemetry to track adapter adoption.
         Pick a field that can uniquely identify one team/organization building with this adapter
         """
-        return json.dumps(self.schemas_and_paths, sort_keys=True)
+        return gethostname()
 
     def _connection_keys(self):
         """ Keys to show when debugging """

--- a/dbt/include/sqlite/macros/adapters.sql
+++ b/dbt/include/sqlite/macros/adapters.sql
@@ -79,14 +79,22 @@
 {% endmacro %}
 
 {% macro sqlite__create_table_as(temporary, relation, sql) -%}
-      create {% if temporary -%}
+    {% set contract_config = config.get('contract') %}
+    {% if contract_config.enforced %}
+        {{exceptions.warn("Model contracts cannot be enforced by sqlite!")}}
+    {% endif %}
+    create {% if temporary -%}
         temporary
-      {%- endif %} table {{ relation }}
-      as
+    {%- endif %} table {{ relation }}
+    as
         {{ sql }}
 {% endmacro %}
 
 {% macro sqlite__create_view_as(relation, sql, auto_begin=False) -%}
+    {% set contract_config = config.get('contract') %}
+    {% if contract_config.enforced %}
+        {{exceptions.warn("Model contracts cannot be enforced by sqlite!")}}
+    {% endif %}
     create view {{ relation }} as
     {{ sql }};
 {%- endmacro %}
@@ -95,15 +103,6 @@
   {# no-op #}  
   {# see SQLiteAdapter.rename_relation() #}
 {% endmacro %}
-
-{% macro sqlite__snapshot_get_time() -%}
-  datetime()
-{%- endmacro %}
-
-{% macro sqlite__snapshot_string_as_time(timestamp) -%}
-    {# just return the string; SQLite doesn't have a timestamp data type per se #}
-    {{ return("'" + timestamp|string + "'") }}
-{%- endmacro %}
 
 {#
 the only allowable schema for temporary tables in SQLite is 'temp', so set
@@ -116,7 +115,3 @@ that here when making the relation and everything else should Just Work
 
     {% do return(tmp_relation) %}
 {% endmacro %}
-
-{% macro sqlite__current_timestamp() -%}
-  datetime()
-{%- endmacro %}

--- a/dbt/include/sqlite/macros/utils/timestamps.sql
+++ b/dbt/include/sqlite/macros/utils/timestamps.sql
@@ -1,0 +1,12 @@
+{% macro sqlite__current_timestamp() -%}
+    datetime()
+{%- endmacro %}
+
+{% macro sqlite__snapshot_string_as_time(timestamp) -%}
+    {# just return the string; SQLite doesn't have a timestamp data type per se #}
+    {{ return("'" + timestamp|string + "'") }}
+{%- endmacro %}
+
+{% macro sqlite__snapshot_get_time() -%}
+    datetime()
+{%- endmacro %}

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         ]
     },
     install_requires=[
-        "dbt-core>=1.4.0"
+        "dbt-core>=1.5.0"
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         ]
     },
     install_requires=[
-        "dbt-core>=1.5.0"
+        "dbt-core~=1.5.0"
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
### Description
Finish changes for compatibility with dbt core v1.4 & v1.5 as per dbts upgrade [guide ](https://github.com/dbt-labs/dbt-core/discussions/7213)

### Change for dbt 1.5 upgrade 
-  include python 3.11 in test matrix
- use standard library `gethostname()` method for anonymous telemetry 
- elegantly stub model contracts as per dbt instructions 
- move timestamp macros 

### Other 
- avoid compatibility issues by using compatible release operator as in [#45 ](https://github.com/codeforkjeff/dbt-sqlite/pull/45)