### PR TITLE
implemented sqlite__datediff macro using epoch deltas

### DIFF
--- a/tests/functional/adapter/utils/test_utils.py
+++ b/tests/functional/adapter/utils/test_utils.py
@@ -124,7 +124,6 @@ class BaseDateDiff(BaseUtils):
         }
 
 
-@pytest.mark.skip("TODO: implement datediff")
 class TestDateDiff(BaseDateDiff):
     pass
 


### PR DESCRIPTION
- I needed to make some empirical adjustments; added comments for discussion
- I referenced [this](https://til.simonwillison.net/sqlite/unix-timestamp-milliseconds-sqlite) as a resource to handle the partial seconds for datepart in ['second', 'millisecond']. This didn't make enough of a difference to matter at coarser dateparts.
- I looked into using julian days, also referenced in the article above, but they turned out to not be as effective as using epoch time for measuring single millisecond differences, since they ended up being orders of magnitude smaller than the smallest epoch time delta, which makes the empirical values have smaller scale. 

Overall I think it feels a bit experimental and I'd like to do more testing against a full calendar table to see if the empirical factors need refinement, or if this implementation needs to be re-thought.